### PR TITLE
feat: user profile endpoints

### DIFF
--- a/backend/internal/handlers/review/review.go
+++ b/backend/internal/handlers/review/review.go
@@ -212,3 +212,16 @@ func (h *Handler) GetReviewsByUser(c *fiber.Ctx) error {
 
 	return c.JSON(reviews)
 }
+
+// SearchUserReviews handles GET /api/v1/review/user/:userId/search?query=...
+func (h *Handler) SearchUserReviews(c *fiber.Ctx) error {
+	userID := c.Params("userId")
+	queryParam := c.Query("query", "") // If query param provided, defaults to empty string
+
+	results, err := h.service.SearchUserReviews(userID, queryParam)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(results)
+}

--- a/backend/internal/handlers/review/review.go
+++ b/backend/internal/handlers/review/review.go
@@ -200,3 +200,15 @@ func (h *Handler) GetComments(c *fiber.Ctx) error {
 	}
 	return c.JSON(comments)
 }
+
+// GetReviewsByUser returns all review documents for a specific user
+func (h *Handler) GetReviewsByUser(c *fiber.Ctx) error {
+	userID := c.Params("userId")
+
+	reviews, err := h.service.GetReviewsByUser(userID)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(reviews)
+}

--- a/backend/internal/handlers/review/routes.go
+++ b/backend/internal/handlers/review/routes.go
@@ -26,4 +26,5 @@ func Routes(app *fiber.App, collections map[string]*mongo.Collection) {
 	review.Delete("/:id", handler.DeleteReview)
 	review.Get("/:id/comments", handler.GetComments)
 	review.Post("/:id/comments", handler.CreateComment)
+	review.Get("/user/:userId", handler.GetReviewsByUser)
 }

--- a/backend/internal/handlers/review/routes.go
+++ b/backend/internal/handlers/review/routes.go
@@ -27,4 +27,5 @@ func Routes(app *fiber.App, collections map[string]*mongo.Collection) {
 	review.Get("/:id/comments", handler.GetComments)
 	review.Post("/:id/comments", handler.CreateComment)
 	review.Get("/user/:userId", handler.GetReviewsByUser)
+	review.Get("/user/:userId/search", handler.SearchUserReviews)
 }

--- a/backend/internal/handlers/review/service.go
+++ b/backend/internal/handlers/review/service.go
@@ -256,3 +256,21 @@ func (s *Service) updateRestaurantAverageRating(restaurantID primitive.ObjectID)
 	_, err = s.restaurants.UpdateOne(ctx, bson.M{"_id": restaurantID}, update)
 	return err
 }
+
+// GetReviewsByUser retrieves all reviews where reviewer.id matches the provided userID
+func (s *Service) GetReviewsByUser(userID string) ([]ReviewDocument, error) {
+	ctx := context.Background()
+	filter := bson.M{"reviewer.id": userID}
+
+	cursor, err := s.reviews.Find(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	var results []ReviewDocument
+	if err := cursor.All(ctx, &results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}

--- a/backend/internal/handlers/review/service.go
+++ b/backend/internal/handlers/review/service.go
@@ -272,5 +272,11 @@ func (s *Service) GetReviewsByUser(userID string) ([]ReviewDocument, error) {
 	if err := cursor.All(ctx, &results); err != nil {
 		return nil, err
 	}
+
+	// Return empty slice instead of nil if no reviews are found
+	if len(results) == 0 {
+		return []ReviewDocument{}, nil
+	}
+
 	return results, nil
 }


### PR DESCRIPTION
## Description

Created endpoints for getting a user’s reviews and searching from a user’s reviews

References and fixes #65.

## Testing
### Getting a user's reviews
#### Finding two reviews from a user with two reviews
<img width="800" alt="Screenshot 2025-03-05 at 6 58 19 PM" src="https://github.com/user-attachments/assets/a2c8c35d-e54e-4cd1-993a-c7ab3b328184" />

#### Finding no reviews from a user with no reviews (empty)
<img width="800" alt="Screenshot 2025-03-05 at 7 03 40 PM" src="https://github.com/user-attachments/assets/ff11ded6-88ac-4e2c-9f31-f47d63d625ec" />

### Searching a user's reviews
- Searching can filter a users reviews using content, menu item, comment content, or restaurant ID

#### Searching Jane Smith’s reviews for “tacos” (filtering content + menu item)
<img width="800" alt="Screenshot 2025-03-05 at 7 24 59 PM" src="https://github.com/user-attachments/assets/ba3a92d0-0a66-4ab6-8fea-4414d398caa4" />

#### Searching Jane Smith’s reviews for “TACOS” (case-insensitivity)
<img width="800" alt="Screenshot 2025-03-05 at 7 28 29 PM" src="https://github.com/user-attachments/assets/ebed0f0f-82db-4166-8b16-7db455f727f3" />

#### Searching Jane Smith’s reviews for “pizza” (empty)
<img width="800" alt="Screenshot 2025-03-05 at 7 26 39 PM" src="https://github.com/user-attachments/assets/49ab7779-a1e1-449b-b9b0-88c3e628efcd" />

#### Searching through comments and not content
(Search "decent" -> Alex’s "Pasta" review comment mentions "decent portion.")
<img width="800" alt="Screenshot 2025-03-05 at 7 30 44 PM" src="https://github.com/user-attachments/assets/53390867-009d-4ee7-812b-8b17b9d8842e" />

#### Searching for a partial word ("burg" -> regex does substring match)
<img width="800" alt="Screenshot 2025-03-05 at 7 36 27 PM" src="https://github.com/user-attachments/assets/d639acf5-89af-455c-b131-0c4a0758400e" />

### Checklist

- [x] I have read the CONTRIBUTING.md.
- [x] I have self-reviewed my code and written tests.
- [x] I have made corresponding changes to the documentation.
- [x] All unit tests are passing locally.
- [x] **I have merged the most recent commit from `main` into my branch.**
